### PR TITLE
fix broken keyEsc functionality

### DIFF
--- a/Source/simple-modal.js
+++ b/Source/simple-modal.js
@@ -298,7 +298,9 @@ provides:
         },
 
         _escape: function(e) {
-            if (e.keyCode == 27) self.hideModal();
+            if (self.options.keyEsc) {
+                if (e.keyCode == 27) self.hideModal();
+            }
         },
 
         /**


### PR DESCRIPTION
- self.options.keyEsc must be true before before checking for e.keyCode == 27
